### PR TITLE
fix: adjust scale factor for double registers

### DIFF
--- a/energymeter2mqtt/cli/cli_app.py
+++ b/energymeter2mqtt/cli/cli_app.py
@@ -218,7 +218,7 @@ def print_values(verbosity: int):
                 assert isinstance(response, ReadHoldingRegistersResponse), f'{response=}'
                 value = response.registers[0]
                 if count > 1:
-                    value += response.registers[1] * 100000
+                    value += response.registers[1] * 65536
 
                 scale = Decimal(str(parameter['scale']))
                 value = value * scale


### PR DESCRIPTION
According to the [manual](https://sbc-support.com/de/produkt-index/axx-energiezaehler/ald1-1-ph-modbus/), the MSB should be multiplied by 65536. I can confirm that the modbus value matches the display value with this factor.